### PR TITLE
Stricter JSON parse when content-type header is application/json.

### DIFF
--- a/chargify.js
+++ b/chargify.js
@@ -28,9 +28,13 @@ Chargify.prototype.request = function(options, callback) {
     };
     request(options, function(err, res, body) {
         if (err) return callback(err);
-        try {
-            var body = JSON.parse(body);
-        } catch(e) {}
+        if (res.headers['content-type'].indexOf('application/json') !== -1 && typeof body !== 'object') {
+            try {
+                res.body = body = JSON.parse(body);
+            } catch(e) {
+                return callback(e);
+            }
+        }
         callback(err, res, body);
     });
 };


### PR DESCRIPTION
Just a little fix to address a problem we had during the Chargify datacenter migration last weekend. Their API was not returning a complete response and therefore the JSON was invalid. Instead of being caught at the source, the unpatched code would allow the body to slip by as a string, causing potential havoc downstream when code get a string instead of an object.

Would love to get this in a release if you have a moment, @natevw.

Thanks!
