### PR TITLE
Fixed erroneous "create new customer" example. The pathname option is ac...

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Load subscription #40:
 Create a new customer:
 
     chargify_site.post({
-        pathname: 'customers.json',
+        uri: 'customers.json',
         json: {
             customer: {
                 first_name: 'Joe',


### PR DESCRIPTION
The pathname option is actually called uri
